### PR TITLE
Fix #2 by trimming the stdlib to between both { }, not just {.

### DIFF
--- a/brython_pack/stdlib.py
+++ b/brython_pack/stdlib.py
@@ -8,7 +8,7 @@ class StdLib:
         self.stdlib = None
         with open(lib_path, encoding="utf-8") as fobj:
             modules = fobj.read()
-            modules = modules[modules.find("{") :]
+            modules = modules[modules.find("{") : modules.rfind("}")+1]
             self.stdlib = json.loads(modules)
 
     def install_requires(self, modules):

--- a/tests/fixtures/brython_stdlib_dummy.js
+++ b/tests/fixtures/brython_stdlib_dummy.js
@@ -1,4 +1,6 @@
-__BRYTHON__ = {
+__BRYTHON__.use_VFS = true;
+var scripts = {
   "testmodule": [".py", "print(\"hello world\")"],
   "testjs": [".js", "console.log(\"hello world\");"]
 }
+__BRYTHON__.update_VFS(scripts)


### PR DESCRIPTION
Brython's stdlib changed format since this was written and now
contains extra data at the end of the JSON data.
This means that trimming the contents of this file to just the
leading { is not enough, we must also find the closing } and
trim to that.
Updated the dummy stdlib file in tests.
With the fix in place, tests once again pass with Brython 3.9.5.